### PR TITLE
don't return to default colour when you press enter

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
     </div>
 
     <div class="container">
-        <form>
+          <form onkeydown="return event.key != 'Enter';">
             <label>Enter a colour:</label>
             #<input id="colour" type="text" maxlength="6" style="width: 60px; font-family: inherit; font-size: 1em; border: 0; border-bottom: 1px solid #222;">
         </form>


### PR DESCRIPTION
Hi Brenton! 

I noticed when I was playing around with this tool, I kept pressing enter out of habit, and that made the colour go back to the default. Adding this line stops that from happening. What do you think?